### PR TITLE
Add native support for WordPress logos

### DIFF
--- a/theme/functions.php
+++ b/theme/functions.php
@@ -86,6 +86,9 @@ if ( ! function_exists( '_tw_setup' ) ) :
 
 		// Remove support for block templates.
 		remove_theme_support( 'block-templates' );
+
+		//Add support for custom logo
+		add_theme_support( 'custom-logo' );
 	}
 endif;
 add_action( 'after_setup_theme', '_tw_setup' );


### PR DESCRIPTION
Hi! :) 

Since ur already declaring support for most of the theme functions wordpress allows I think it would be beneficial also to add support for custom logos so that you can use WordPress's native features & functions relating to website logos.

While using _tw this is a key feature that I noticed was missing and having to add it every single time is a bit of a bummer that I think should be supported from when u download the theme.